### PR TITLE
Security fixes for cmd-@register

### DIFF
--- a/security-fix/README.md
+++ b/security-fix/README.md
@@ -1,0 +1,6 @@
+# Security Fixes for Old MUFs
+
+This directory contains MUFs that are no longer necessary due to FB7 replacements, but have some sort of known security problem that will impact previous MUCK versions to the point where it is recommended they be upgraded even if there is no intention to upgrade to FB7.
+
+At the time of this writing, the only thing in here is @register -- if you are using FB7, you really don't need this MUF any more as the built-in has all the functionality of the MUF version.
+

--- a/security-fix/cmd-@register.muf
+++ b/security-fix/cmd-@register.muf
@@ -1,0 +1,292 @@
+@program cmd-@register.muf
+1 100000 d
+i
+$define .tell me @ swap notify $enddef
+$define sls striplead $enddef
+$define sts striptail $enddef
+$define strip sls sts $enddef
+    
+lvar regobj
+lvar regprop
+    
+: split
+    swap over over swap
+    instr dup not if
+        pop swap pop ""
+    else
+        1 - strcut rot
+        strlen strcut
+        swap pop
+    then
+;
+    
+ 
+( Determines if I'm allowed to set prop 's'.  Only wizards can set
+  wizard props. )
+: allowed_prop? ( s -- b )
+    me @ "WIZARD" flag? if
+        pop 1 exit ( Wizards can set anything )
+    then
+    
+    ( We cannot start with @ or ~, and we cannot have /@ or /~ in the
+      prop string )
+    dup dup "~" stringpfx swap "@" stringpfx or if
+        pop 0 exit
+    then
+    
+    dup dup "/~" instring swap "/@" instring or if
+        pop 0 exit
+    then
+    
+    pop 1
+;
+  
+( returns #-1 if prop not found.  #-2 if has bad value. )
+: get_propref (d s -- d)
+    over over
+    getprop
+    
+    (* Note: What this used to do, is the prop was a string or an
+     * integer and not a 'ref', it would try to 'atoi dbref' it,
+     * and if the value of the string/integer returned a ref, it would
+     * re-store it as a ref thus destroying original data.
+     *
+     * My options were to either have it do an atoi dbref and return
+     * the ref which would non-destructively mimic the old behavior,
+     * or have it return #-2 for all strings and integers.
+     *
+     * I chose to do the latter because that seems more true to the
+     * spirit and security of the program.  Parsing random strings and
+     * integers into ref's just doesn't make sense to me and seems like
+     * a legacy relic.
+     *
+     * Of course, that decision may break @register's expected behavior
+     * on some MUCKs that have registrations improperly configured, so
+     * that is why there is this lengthly explanation.  For those MUCKs,
+     * it is recommmended that you re-register your broken props rather
+     * than modify this code.
+     *)
+    dup if
+        dup dbref? not if pop #-2 then
+    else
+        pop #-1
+    then
+    rot rot pop pop
+;
+  
+  
+( makes user readable string rep of registered prop )
+: pretty_propref (d s -- s)
+    over over get_propref
+    dup if
+        dup ok? if
+            dup unparseobj
+            over "_version" getpropstr
+            dup if
+                "     Ver. " swap strcat strcat
+            else pop
+            then
+            swap "_lib-version" getpropstr
+            dup if
+                "     Lib.ver. " swap strcat strcat
+            else pop
+            then
+        else pop "<garbage>"
+        then
+        over ": " strcat swap strcat
+        regprop @ strlen strcut swap pop
+    else pop ""
+    then
+    rot rot pop pop
+;
+  
+  
+: list-props ( d s -- )
+    begin
+        dup while
+        dup strlen 1 - strcut
+        dup "/" strcmp if
+            strcat break
+        else pop
+        then
+    repeat
+    "/" strcat over swap nextprop
+        
+    begin
+        dup while
+
+        ( Don't show @ props -- but do show ~ props )
+        dup dup "@" stringpfx swap "/@" instring or if
+          over swap nextprop continue
+        then
+
+        over over pretty_propref
+        dup if
+            "  " swap strcat .tell
+        else
+            pop
+        then
+        over over propdir? if
+            dup regprop @ strlen strcut swap pop
+            "    " swap strcat
+            "/ (directory)" strcat .tell
+        then
+        over swap nextprop
+    repeat
+    pop pop
+;
+    
+: do-help
+"Syntaxes:"
+"  The following prefixes set what the target object and the target propdir"
+"   are.  The default target propdir is \"_reg/\" and the default target"
+"   object is #0."
+"      #me"
+"          Sets target object to you, and propdir to the default \"_reg/\"."
+"      #prop <targobj>:<propdir>"
+"          Sets target object to <targobj> and propdir to <propdir>."
+"  The following are the command syntaxes"
+"      @register [<prefix>]"
+"          List all registered objects in the target propdir on target object."
+"      @register [<prefix>] <subpropdir>"
+"          List all registered objects in <subpropdir> in the target propdir."
+"      @register [<prefix>] <object> = <name>"
+"          Register <name> to <object> in the propdir on the target object."
+"Example: @register #prop here:_disconnect gen-sweeproom=cleanup"
+"  This registers the program gen-sweeproom as 'cleanup' in the _disconnect"
+"   propdir on the current room."
+    18
+    begin
+         dup while
+         dup 1 + rotate .tell
+         1 -
+    repeat
+;
+    
+: cmd-@register
+    "me" match me !
+    dup "#help" stringcmp not if
+        do-help exit
+    then
+    sls dup tolower "#me" 3 strncmp not if
+        " " split swap pop
+        me @ regobj !
+        "_reg/" regprop !
+    else
+        dup tolower "#prop" 5 strncmp not if
+            " " split swap pop
+            " " split swap
+            ":" split
+            (rest obj prop)
+            swap dup not if pop "me" then
+            dup "@" strcmp not if pop "#0" then
+            match dup not if
+                me @ "I don't see that target object here." notify
+                pop pop pop exit
+            then
+            dup #-2 dbcmp if
+                me @ "I don't know which target object you mean." notify
+                pop pop pop exit
+            then
+            me @ over owner dbcmp
+            me @ "wizard" flag? or not if
+                me @ "Permission Denied." notify
+                pop pop pop exit
+            then
+            regobj !
+            (rest prop)
+ 
+            dup not if
+                (if no propdir selected, error out)
+                me @ "You have to specify a propdir." notify
+                pop pop exit
+            then
+            dup dup strlen 1 - strcut swap pop
+            "/" strcmp if "/" strcat then (if doesn't end in /, append /)
+            regprop !
+        else
+            me @ "w" flag? not
+            over "=" instr and if
+                me @ "Permission denied." notify
+                pop exit
+            then
+            #0 regobj !
+            "_reg/" regprop !
+        then
+    then
+    
+    dup "=" instr not if
+        regobj @ dup #0 dbcmp swap me @ dbcmp or not if
+            "You need to specify a value to set with @reg #prop" .tell
+            pop exit
+        then
+        "Registered objects on "
+        regobj @ unparseobj strcat
+        ":" strcat .tell
+        regobj @ regprop @ rot strcat list-props
+        "Done." .tell exit
+    then
+    "=" split strip
+    dup not if "You must specify a registration name." .tell exit then
+    swap strip
+    dup not if
+        pop  (Nothing to register; remove $regname)
+        " " split if
+            pop pop "You cannot have spaces in the registration name." .tell exit
+        then
+        regobj @ regprop @ 3 pick strcat 
+        
+        dup allowed_prop? not if
+            "You are not allowed to remove that property." .tell pop pop exit
+        then
+        
+        pretty_propref
+        dup if
+            "Used to be registered as "
+            regprop @ strcat swap strcat
+            .tell
+        else pop "No entry to remove." .tell exit
+        then
+  
+        regobj @ regprop @ 3 pick strcat remove_prop
+  
+        "Registry entry " regprop @ strcat swap strcat
+        " on " strcat regobj @ unparseobj " removed." strcat strcat
+        .tell
+    else
+        match dup not if
+            "I don't see that object here." .tell pop exit
+        then
+        dup #-2 dbcmp if
+            "I don't know which object you mean." .tell pop exit
+        then
+        
+        swap " " split if
+            pop pop "You cannot have spaces in the registration name." .tell exit
+        then
+        regobj @ regprop @ 3 pick strcat pretty_propref
+        dup if
+            "Used to be registered as "
+            regprop @ strcat swap strcat
+            .tell
+        else pop
+        then
+      
+        regobj @ regprop @ 3 pick strcat
+        
+        dup allowed_prop? not if
+            "You are not allowed to set that property." .tell pop pop exit
+        then
+        
+        4 pick setprop
+      
+        regobj @ regprop @ 3 pick strcat
+        pretty_propref "Now registered as "
+        regprop @ strcat swap strcat
+        " on " strcat regobj @ unparseobj strcat
+        .tell
+    then
+;
+.
+c
+q


### PR DESCRIPTION
Please note that the majority of this is not my code and so the janky spacing, lack of comments, etc. are not mine.  This is the probably-latest cmd-@register from Hope Island.

It fixes the following problems:

* The scrambling of properties.  The old @ register iterate over your properties on list, and if a property was either an integer or a string that would resolve with atoi dbref to a DBREF, it would *setprop* the ref value of the property ... this overwriting your property!  Which is never expected on a list.  I don't know who thought that was a good idea.  You can test this with the following commands:

```
@set me=foo/intval:1
ex me=foo/**
@register #prop me:foo
ex me=foo/**
```

On old @ register, 'foo/intval' will be set to a ref to One (# 1).  The new register will show it up as ```<garbage>``` instead which is how @ register displays props it doesn't know what to do with.

* Further, if you have @ register set WIZARD (which is really not required, by the way), players can set wizard props on themselves and browse + mangle wizard prop directories.  It seems common for MUCKs to have @ register set WIZARD including the big guys who will remain nameless.

The following commands demonstrate this:

```
@reg #prop me:test me=~testing
ex me=test/~testing
@reg #prop me:test me=@testing/test
say Note: You will not see your hidden prop with the ex...
ex me=test/
say ... but you will see it with the @reg
@reg #prop me:test
```

This new @ register resolves this problem as well, and neither allows listing of hidden props nor setting/removing of any wizard props.
