### PR TITLE
Tweaks for FB7 and hammers

### DIFF
--- a/cmd-editroom.muf
+++ b/cmd-editroom.muf
@@ -41,16 +41,15 @@ $def USE_QUOTA  1
  * MUCKs, the off value is an empty string,
  *)
 $def OBVEXITS_PROP  "_/sc"
-$def OBVEXITS_ON    "@$exits"
+$def OBVEXITS_ON    "@$obvexits"
 $def OBVEXITS_OFF   ""
  
 (* END CONFIGURATION *)
  
 $include $lib/editor
 $include $lib/lmgr
-$include $lib/findparent
 $include $lib/tabtoolkit
- 
+
 $ifdef USE_QUOTA
 $include $lib/quota
 $else
@@ -318,7 +317,7 @@ $endif
     pop #-1 exit
   then
   
-  me @ location findparent swap newroom
+  me @ location location swap newroom
   
   (* Make sure it worked -- this should never fail *)
   dup room? not if
@@ -778,7 +777,7 @@ $endif
         "You do not have enough "
         "pennies" sysparm strcat " to build a new room." strcat tell
       else
-        me @ location findparent swap newroom
+        me @ location location swap newroom
         ToEdit @ swap moveto
         
         me @ Exempt? not if

--- a/lib-ansi-fb6.muf
+++ b/lib-ansi-fb6.muf
@@ -1,0 +1,375 @@
+@prog lib-ansi-fb6.muf
+1 9999 d
+i
+( lib-ansi-fb6.muf by Wog
+  For FuzzBall Version 6 to simulate tidle ansi-color.
+
+ NOTE: Tidle ansi color is primarily for backwards compatibility
+  if you don't care about backwards compatibility with 
+  pre-fuzzball 6 lib-ansi systems you should see 'man textattr' or
+  'mpi attr'.
+  
+Info about tidle ansi escapes:
+ Color can be changed with an escape of the form: ~&<A><F><B>
+<A> is the attribute, one of:
+   1 => bold
+   2 => reverse
+   3 => bold and reverse
+   4 => underline [ in theory ]
+   5 => flash
+   8 => also reverse
+   - => no change from what it was before
+
+<F> is the foreground, one of:
+   0 => black
+   1 => red
+   2 => green
+   3 => yellow
+   4 => blue
+   5 => magenta
+   6 => cyan
+   7 => white
+   - => no change from what it was before
+
+<B> is the background, one of:
+   0 => black
+   1 => red
+   2 => green
+   3 => yellow
+   4 => blue
+   5 => magenta
+   6 => cyan
+   7 => white
+   - => no change from what it was before.
+ Other codes supported:
+  ~&R -- to reset colors...
+
+ Other notes:
+  \~& or ~&~& will put a literal ~& without doing ansi codes...
+
+ Semi-bugs:
+  ansi-strcut will NOT preserve \~& exactly; in the results they
+  will be replaced with ~&~&, except when ansi_strcut is returning
+  anot string for either of it's return values.
+
+ NOTE:
+   ansi_version will return '200' for this library.
+
+--- Change History ----------------------------------
+v 1.0  02/24/00
+    Assignment of version number to programs.
+v 1.01 02/25/00
+    Modified _defs/ansi-codecheck to deal with - in escape codes.
+v 1.02 03/31/00
+    Enhanced setup script a bit.
+v 2.0 May 20 2000
+    Used ANSI codes directly, rather then textattr, so - works
+    as expected. Actaully wrote own ansi_strcut routine, fixing
+	problems that would be suffered with old one. Also added public
+	routines for any program that might try calling lib-ansi directly.
+    [as in "$lib/ansi" match "ansi-tell" call], rather than
+    using this libraries _defs. 
+v 2.0a Apr 12 2001
+    Added some nice _defs and used Natty's ansi-strcut routine from
+    lib-ansi-burn. [Which works, I hope.]
+--- Distrubution Information ------------------------
+Copyright {C} Charles "Wog" Reiss <car@cs.brown.edu>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or {at your option} any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+For a copy of the GPL:
+   a> see: http://www.gnu.org/copyleft/gpl.html
+   b> write to: the Free Software Foundation, Inc., 
+     59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+GNU Public License Version 2 or at your option any later version. 
+)
+
+(For the benefit of those reading this code who aren't aware of this, 
+  in FB6 \[ represents the escape charactor in strings. 
+  That's ASCII code 27 decimal, and this convient table is provided if
+  you want it in another base. <;
+  [Yes! I do have too much time!]
+Base      Number  Base      Number  Base      Number
+  2        11011    3         1000    4          123
+  5          102    6           43    7           36
+  8           33    9           30   10           27
+ 11           25   12           23   13           21
+ 14           1D   15           1C   16           1B
+ 17           1A   18           19   19           18
+ 20           17   21           16   22           15
+ 23           14   24           13   25           12
+ 26           11   27           10   28            R
+ 29            R   30            R   31            R
+ 32            R   33            R   34            R
+ 35            R   36            R
+)
+
+(Protect strings should be 2 chars long since ~& is for ansi_strcut.)
+$def PROTECT_STR "\[\["
+                 
+
+( s   -- s'  )
+$define _protect
+  PROTECT_STR "\\~&" subst
+  PROTECT_STR "~&~&" subst
+$enddef
+
+( s'  -- s'' )
+$define _end_protect
+  "~&" PROTECT_STR subst
+$enddef
+
+( s' -- s  ) ( * almost; \~& will be replaced with ~&~&. )
+$define _cut_end_protect
+  "~&~&" PROTECT_STR subst
+$enddef
+
+( This can be changed if you don't want black on white to be the default
+  color. )
+$def RESET_CODE "\[[0;37;40m"
+
+: tCodeData ( s -- s )
+(Generate like:
+  070 -> "\[[0;37;40m"
+  --- -> ""
+  8-- -> "\[[8m"
+)
+  dup  "---" strcmp not if pop "" exit then
+  ( ^^ Special Case ^^ )
+  "\[["
+( We add 1 to the string so - turns into -1, not 0, for us
+   to not touch in the case statment. )
+  swap 
+  ("\[[" AFB)
+  1 strcut
+  ( "\[[" A FB )
+  over "-" strcmp not if (Attribute)
+  ( "\[[" A FB )
+    swap pop
+  else
+    rot rot
+  ( FB "\[[" A )
+	strcat ";" strcat swap 
+  then
+  ( "\[[..." FB )
+  1 strcut
+  ( ... F B )
+  over "-" strcmp not if (Forground)
+    swap pop ( "\[[" B )
+  else
+    rot "3" strcat rot strcat ";" strcat swap
+  then
+  ("\[[" B)
+  
+  dup "-" strcmp not if
+    pop
+	dup strlen 1 - strcut pop
+  else
+    swap "4" strcat swap strcat
+  then
+  "m" strcat
+;
+
+lvar data
+lvar oddness
+lvar append
+: t_ansify ( s -- s )
+  "" data !
+  _protect
+  dup "~&" instr not if
+    _end_protect exit
+  then
+  RESET_CODE "~&R" subst
+  RESET_CODE "~&r" subst
+  dup "~&" instr 1 = oddness !
+  "~&" explode
+  oddness @ not if
+     swap append ! 1 - 
+  else
+     "" append !
+  then
+  begin 
+    dup while
+    dup 1 + rotate
+    dup if
+      dup "[-0-9][-0-9][-0-9]*" smatch if
+        3 strcut swap tCodeData 
+	    swap strcat 
+      then
+    then
+    data @ strcat data !
+    1 -
+  repeat
+  pop
+  append @ data @ strcat
+  _end_protect
+;
+
+: ansify ( s -- s' ) 
+  t_ansify
+;
+PUBLIC ansify
+
+: ansi-strip ( s -- s' )
+  _protect
+  "" "~&R" subst
+  "" "~&r" subst
+  dup "~&" instr not if _end_protect exit then
+  "" data !
+  "~&" explode
+  begin
+    dup while
+    dup 1 + rotate
+    dup if
+      dup "[-0-9][-0-9][-0-9]*" smatch if ( We allow up to nine, just because. )
+        3 strcut swap pop
+      then
+    then
+    data @ strcat data !
+    1 -
+  repeat
+  pop
+  data @ _end_protect
+;
+PUBLIC ansi-strip
+
+(Returns length of ansi code following ~&. 
+ As in you can give it 06-Cyan!
+ Or RResetted.., etc. as an argument.
+)
+: code-length ( s -- i )
+  dup 1 strcut pop "R" stringcmp not if pop 3 exit then
+  3 strcut pop
+  "[-0-9][-0-9][-0-9]" smatch if 5 else 0 exit then
+;
+
+
+lvar stringprime
+( This is taken's from Natty's lib-ansi-burn, a GPL library. )
+: ansi-strcut ( s i -- s' -s }  Strcuts, dancing around ~&AFB codes; -s=the end of s, s-=the startish part )
+  swap  ( i s )
+ 
+  ( Protect protected ansi. )
+  _protect
+ 
+  ( I worked this like an abacus, character by character, but it was stupidslow; now 
+it skips ahead with instr to the next instance of ~&, and should be faster. 
+Hopefully. )
+  "" stringprime !
+  begin over over and while  ( i s }  While there are still chars left in i, )
+    dup "~&" instr dup if  ( i s i' }  i' = Where's the next ~&? )
+      dup 4 pick <  ( i s i' b }  b = Is the next ~& after the place we should cut? )
+    else 0 then  ( i s i' b }  b = Do I haveta cut? )
+ 
+    if  ( i s i' )
+      1 - strcut  ( i s- -s )
+      rot 3 pick strlen - -3 rotate  ( i s- -s }  Reduce i by 's- strlen'. )
+      stringprime @ rot strcat stringprime !  ( i -s )
+      3 strcut over tolower "~&r" strcmp if  ( i -s- -s } -s- is the ansi code. )
+        2 strcut -3 rotate strcat
+      else swap then ( i -s -s- )
+      stringprime @ swap strcat stringprime !  ( i -s )
+    else
+      pop swap strcut  ( s- -s )
+      stringprime @ rot strcat stringprime !  ( -s )
+      0 swap  ( i -s )
+    then
+  repeat  ( i -s )
+ 
+  swap pop  ( -s )
+  _cut_end_protect
+  stringprime @
+  _cut_end_protect
+  swap  ( s- -s )
+;
+PUBLIC ansi-strcut
+
+: ansi-codecheck "{r|R|[-0-9][-0-9][-0-9]}" smatch ;
+PUBLIC ansi-codecheck
+: ansify_string ansify ;
+PUBLIC ansify_string
+: ansi-notify ansify \notify ;
+PUBLIC ansi-notify
+: ansi-notify-except ansify 1 swap \notify_exclude ;
+PUBLIC ansi-notify-except
+: ansi-notify-exclude ansify \notify_exclude ;
+PUBLIC ansi-notify-exclude
+: ansi-tell ansify tell ;
+PUBLIC ansi-tell
+: ansi-otell ansify otell ;
+PUBLIC ansi-otell
+: ansi-strlen ansi-strip \strlen ;
+PUBLIC ansi-strlen
+: ansi-connotify ansify \connotify ;
+
+lvar setup_tmp
+: setup ( -- )
+  "me" match me !
+  me @ "W" flag? not if
+    "Only wizards can setup this library!" tell
+    exit
+  then
+  "** Setting up lib-ansi! **" tell
+  prog "S" set
+  prog "H" set
+  prog "L" set
+  "%% Setup program SETUID, HARDUID, and LINK_OK" tell
+  prog "_defs/lib-ansi" "#" prog int intostr strcat setprop
+  prog "_defs/doAnsify" "lib-ansi \"ansify\" call" setprop
+  prog "_defs/ansify_string" "doAnsify" setprop
+  prog "_defs/ansi-codecheck" "\"{r|R|[-0-9][-0-9][-0-9]}\" smatch" setprop
+  prog "_defs/ansi_codecheck" "ansi-codecheck" setprop
+  prog "_defs/ansi_protect" "\"\\~&\" \"~&\" subst" setprop
+  prog "_defs/ansi-strip" "lib-ansi \"ansi-strip\" call" setprop
+  prog "_defs/ansi_strip" "lib-ansi \"ansi-strip\" call" setprop
+  prog "_defs/ansi-version" "200" setprop (Emulate lib-ansi-free with extra feeps!)
+  prog "_defs/ansi_version" "ansi-version" setprop
+  prog "_defs/ansi-strlen" "ansi-strip \\strlen" setprop
+  prog "_defs/ansi_strlen" "ansi-strip \\strlen" setprop
+  prog "_defs/ansi_notify" "doAnsify \\notify" setprop
+  prog "_defs/ansi-notify" "doAnsify \\notify" setprop
+  prog "_defs/ansi_notify_except" "doAnsify 1 swap \\notify_exclude" setprop
+  prog "_defs/ansi_notify_exclude" "doAnsify \\notify_exclude" setprop
+  prog "_defs/ansi-notify-except" "doAnsify 1 swap \\notify_exclude" setprop
+  prog "_defs/ansi-notify-exclude" "doAnsify \\notify_exclude" setprop
+  prog "_defs/ansi_notify-except" "doAnsify 1 swap \\notify_exclude" setprop
+  prog "_defs/ansi_notify-exclude" "doAnsify \\notify_exclude" setprop
+  prog "_defs/ansi_otell" "doAnsify loc @ me @ rot 1 swap \\notify_exclude" setprop
+  prog "_defs/ansi-otell" "doAnsify loc @ me @ rot 1 swap \\notify_exclude" setprop
+  prog "_defs/ansi-tell" "doAnsify me @ swap \\notify" setprop
+  prog "_defs/ansi_tell" "doAnsify me @ swap \\notify" setprop
+  prog "_defs/ansi-strcut" "lib-ansi \"ansi-strcut\" call" setprop
+  prog "_defs/ansi_strcut" "lib-ansi \"ansi-strcut\" call" setprop
+  prog "_defs/ansi?" "owner \"C\" flag?" setprop
+  
+  "%% Setup _defs." tell
+  "%% Registering library!" tell
+  
+  "@register" match 
+  dup ok? not if
+    pop #0 "_reg/lib/ansi" prog setprop
+  else (Prefer @register messages of any changes, etc.)
+    getlink "#" prog int intostr strcat "=lib/ansi" strcat swap call  
+  then
+  
+  "%% Done!" tell
+;
+.
+c
+ansi_tell kill
+ansi_otell kill
+def ansi_tell ( s -- ) me @ swap "$lib/ansi" match "ansify" call \notify
+def ansi_otell ( s -- ) loc @ me @ rot "$lib/ansi" match "ansify" call \notify_except
+q
+@set lib-ansi-fb6.muf=W
+@mpi {muf:lib-ansi-fb6.muf,}
+whis me=Uncompiling all programs, so they will adapt to new calling interface, hopefully.
+@uncompile

--- a/lib-tabtoolkit.muf
+++ b/lib-tabtoolkit.muf
@@ -225,7 +225,7 @@
   0
   begin
     dup counter @ < while
-    dup tab @ swap [] .tell
+    dup tab @ swap [] tell
     1 +
   repeat
   pop

--- a/obvexits.muf
+++ b/obvexits.muf
@@ -1,0 +1,401 @@
+( ObvExits.muf     by Gyroplast   10/17/00     v2.15
+  Shows exits in a room beneath the description.
+ 
+  Wizards are encouraged to register this program as $obvexits, since
+  this is an inofficial established standard.
+  To show exits in your room, set it's SUCC to @$obvexits, ex.:
+    @succ here=@$obvexits
+ 
+  ** DETAILED HELP AVAILABLE BY RUNNING THE PROGRAM FROM AN ACTION **
+ 
+  If you dont want an exit to show up in the list, set it DARK or set
+  the _invisible property to 'yes'. ex:  @set <exit>=_invisible:yes
+ 
+  To show an exit regardless of where it's linked to, set the
+  _visible property to 'yes'. ex:  @set <exit>=_visible:yes
+ 
+  If you'd like a different prefix than "Exits: ", set it into the
+  _obvexits/prefix property on the room. "Exits: " is default.
+    ex: @set <room>=_obvexits/prefix:Obvious Exits:
+ 
+  The string added between the exits can be set by changing the
+  _obvexits/delimiter property. If it's not set, the default define below
+  will be used. 
+  
+  The program will look thru the whole environment for any settings.
+)
+ 
+$def USEANSI                   ($undef this if you dont want ANSI )
+ 
+$def HEADER "ObvExits v2.15 by Gyroplast@FuzzyLogic"
+ 
+$ifdef USEANSI
+$include $lib/ansi
+ 
+  $def PFX_DEF_COLOR "160"     ( Default color for "Exits: " prefix )
+  $def EXT_DEF_COLOR "140"     ( Default color for exits themselves )
+  $def PRG_DEF_COLOR "060"     ( Default color for program actions )
+  $def DRK_DEF_COLOR "200"     ( Default color for invisible exits )
+  $def DLM_DEF_COLOR "160"     ( Default color for exit delimiter )
+  $def UNL_DEF_COLOR "510"     ( Default color for unlinked exits )
+  $def RST           "~&R"     ( ANSI reset code )
+  
+  $def HEADER "ObvExits v2.15 by Gyroplast@FuzzyLogic  [ ANSI ENABLED ]"
+$endif
+ 
+$def ScreenWidth 76            ( needed for line wrapping function )
+$def DefaultPrefix    "Exits:" ( string prefixing the exitlist )
+$def DefaultDelimiter "  -  "  ( string catted between exits )
+LVAR ListString                ( string containing exitlist )
+LVAR ListLength                ( needed for line wrapping function )
+(   ExitVisible?
+    This function is pretty much the heart of the program. If you dont like
+    how the determination of visibility is handled, or you need other/more
+    _visible properties on your muck, you should edit this function
+    accordingly. It's kept rather linear for this purpose.
+)
+: ExitVisible? ( [ d -- b ] - Is exit d shown in the list? )
+  ( 1. Wizzes and owners _always_ see exits, if their debug prop is set. )
+  me @ "W" flag?       ( is wizzard.. )
+  over owner me @ owner dbcmp OR   ( .. OR owner? )
+  me @ "_obvexits/debug" getpropstr ( ..AND has debug flag set? )
+  "y" stringpfx 1 = AND   
+  if
+    pop 1 exit                      ( show da dark stuph! )
+  then
+ 
+  ( 2. Exits set DARK are invisible, regardless of props. )
+  dup "D" flag? if
+    pop 0 exit
+  then
+ 
+  ( 3. Check for properties. )
+  ( These properties are to be used to force display of an exit before )
+  ( the 'sanity' routines rule them out later. Used for program links. )
+ 
+  dup 
+  "_visible?" getpropstr 
+  "y" stringpfx 1 = if      ( '_visible?' set to 'yes' ?)
+    pop 1 exit
+  then
+ 
+  dup 
+  "_visible" getpropstr 
+  "y" stringpfx 1 = if      ( '_visible' set to 'yes' ?)
+    pop 1 exit
+  then
+ 
+  dup 
+  "visible" getpropstr 
+  "y" stringpfx 1 = if      ( 'visible' set to 'yes' ?)
+    pop 1 exit
+  then
+  
+ 
+  ( 4. We dont need to show unlinked exits, do we. Of course not.  )
+  (    Only links to rooms will be shown unless a property is set. )
+  (    This might cause major confusion to unsuspecting people!    )
+  dup getlink room? not if
+    pop 0 exit
+  then 
+ 
+  pop 1                     ( exit is by default visible )
+;
+ 
+: GetExitName  ( [ d -- s ] - Return first name part of exit d )
+$ifdef USEANSI
+  dup
+$endif
+ 
+  name
+  dup ";" instr dup if
+    1 - strcut
+  then
+  pop
+ 
+$ifdef USEANSI
+ 
+  over "d" flag? if              ( Check is exit is dark )
+    RST strcat                   ( Append reset code )
+    swap "_obvexits/color/dark"  ( get custom DARK EXIT color.. )
+    envpropstr                   ( ..from the exit down the environment )
+    dup not if                   
+      pop DRK_DEF_COLOR          ( nothing found, use default )
+    then
+    swap pop                     ( cleanup )
+    "~&" swap strcat             ( prepend ansi code )
+    swap strcat                  ( prepend complete ansi color code to name )
+    exit                         ( we're done here )
+  then
+ 
+  over getlink program? if       ( Repeat above procedure for exit->prog )
+    RST strcat
+    swap "_obvexits/color/program"
+    envpropstr
+    dup not if
+      pop PRG_DEF_COLOR
+    then
+    swap pop
+    "~&" swap strcat
+    swap strcat
+    exit
+  then
+  
+  over getlink #-1 dbcmp if 
+    RST strcat
+    swap "_obvexits/color/unlinked"
+    envpropstr
+    dup not if
+      pop UNL_DEF_COLOR
+    then
+    swap pop
+    "~&" swap strcat
+    swap strcat
+    exit
+  then
+ 
+  RST strcat                   ( finally ansify any other exit with defaults )
+  swap "_obvexits/color/normal"
+  envpropstr
+  dup not if
+    pop EXT_DEF_COLOR
+  then
+  swap pop
+  "~&" swap strcat
+  swap strcat
+$endif
+;
+ 
+: GetDelimiter ( [  -- s ] - Return exit delimiter )
+  trigger @ "_obvexits/delimiter" envpropstr
+  dup not if
+    pop DefaultDelimiter
+  then
+  swap pop
+ 
+$ifdef USEANSI
+  RST strcat
+  
+  trigger @ "_obvexits/color/delimiter"
+  envpropstr
+  dup not if
+    pop DLM_DEF_COLOR
+  then
+  swap pop
+  "~&" swap strcat
+  swap strcat
+$endif
+;
+ 
+: GetPrefix  ( [  -- s ] - Return ObvExits listprefix )
+  trigger @ 
+  "_obvexits/prefix" envpropstr
+ 
+  dup not if
+    pop DefaultPrefix
+  then
+  swap pop
+ 
+$ifdef USEANSI
+  RST strcat
+  
+  trigger @ "_obvexits/color/prefix"
+  envpropstr
+  dup not if
+    pop PFX_DEF_COLOR
+  then
+  swap pop
+  "~&" swap strcat
+  swap strcat
+$endif
+;
+ 
+: ListEmpty?  ( [  -- b ] - Check if no exits have been added to the list )
+  GetPrefix " " strcat    ( create a string equal to an empty list )
+  ListString @ strcmp     ( compare it with our current list )
+  not                     ( invert returned 0 -> 1 if no difference )
+;
+ 
+: NewLine  ( [  --  ] - Start new line in ListString )
+  ListString @    ( get list and add a newline )
+  "\r" strcat
+  ( now indend the new line, ie. get length of prefix and add 'strlen' spaces )
+  "                                                                         "
+  GetPrefix strlen 1 +
+$ifdef USEANSI
+  8 - 
+$endif 
+  dup ListLength !        ( store length of padding in listlength )
+  strcut pop
+  strcat
+  ListString !
+;
+ 
+: ExceedWidth?  ( [ s -- b ] - Does ListString + s exceed ScreenWidth? )
+  strlen 1 +                 ( get effective length of exit name )
+$ifdef USEANSI
+  8 -
+$endif 
+  dup 
+  ListLength @ +             ( add to listlength and keep a copy for later )
+  ListLength !               ( store updated listlength )
+  
+  ScreenWidth > if           ( see if exit alone is longer than allowed )
+    0 exit                   ( return 0 if it is to avoid endless loop )
+  then
+ 
+  ListLength @ ScreenWidth >   ( final comparison )
+;
+ 
+: AddToList  ( [ s --  ] - Add exitname s to liststring )
+  dup ExceedWidth? if     ( does the list exceed max width with new exit? )
+    NewLine               ( yup, it does. Start new line. )
+    ListString @          ( Get the liststring )
+    swap strcat           ( Add exit to the list in the new line w/o delimiter )
+  else
+    ListString @          ( nope, does not exceed maxwidth )
+    ListEmpty? not if     ( only cat delimiter if list is not empty )
+      GetDelimiter strcat ( cat delimiter )
+                          ( Add effective delimiter length to listlength )
+      ListLength @        ( fetch old length )  
+      GetDelimiter        ( retrieve delimiter and substract length of ansi )
+      strlen 1 +          ( add effective delimiter length to listlength )
+ $ifdef USEANSI
+   8 - 
+ $endif 
+      +
+      ListLength !        ( store listlength )
+    then
+    swap strcat           ( cat exit )
+  then
+ 
+  ListString !            ( store edited list anew )
+;
+ 
+: BuildList-loop  ( [  --  ] - Main function for list assembly )
+  GetPrefix " " strcat      ( get optional custom prefix, add space )
+  dup ListString !          ( initialize liststring )
+  strlen 1 +
+$ifdef USEANSI
+  8 -
+$endif 
+  ListLength !              ( init listlength with length of prefix - ansi )
+ 
+  trigger @ exits       ( get first exit in current room )
+  BEGIN
+    dup #-1 dbcmp not while ( while we can get valid exits... )
+ 
+    dup ExitVisible? if     ( ...check if the exit to be shown. )
+      dup                   ( Keep a copy of the dbref for 'next' )
+      GetExitName           ( self explanatory.. )
+      AddToList             ( also self explanatory.. isnt this simple? ;)
+    then
+    next                    ( get next exit's dbref )
+  REPEAT
+  pop                       ( pop off the #-1 )
+  ListEmpty? if             ( if no exits have been added... )
+    "None" AddToList        ( ...tell us their are no obvious exits. )
+  then
+ 
+  ListString @
+  me @ swap                 ( Finally! Print out the freakin' list! )
+$ifdef USEANSI
+  ansi_notify
+$else
+  notify
+$endif
+;
+: Underline  ( [ s -- s' ] - Generate a line as long as s )
+  strlen 1 +
+  "---------------------------------------------------------------------"
+  swap strcut pop
+;
+: ShowGeneralHelp  ( helpscreen one )
+  HEADER dup tell
+  Underline tell
+  " " tell
+  "          GENERAL HELP AND USAGE" tell
+  " " tell
+  "   This is a highly customizable, intelligent and hopefully fool" tell
+  "   proof implementation of the well known ObviousExits concept," tell
+  "   supporting ANSI optionally." tell
+  " " tell
+  "   To enable ObvExits in your room(s), @succ <room>=@$obvexits" tell
+  "   To disable it again, just type @succ <room>=" tell
+  " " tell
+  "   You can find out more about general customization in #help2" tell
+  " " tell
+;
+: ShowHelp2
+  HEADER dup tell
+  Underline tell
+  " " tell
+  "          CUSTOMIZING THE APPEARANCE OF THE EXIT LIST" tell
+  " " tell
+  "   The exit list shown to the looker is split into three parts." tell
+  "   1) The prefix (default: \"Exits: \")" tell
+  "   2) The exits themselves" tell
+  "   3) The exit delimiter shown between the exits (default: \"  -  \")" tell
+  " " tell
+  "   You can customize 1) and 3) to your liking. For reference:" tell
+  "     Prefix:     _obvexits/prefix" tell
+  "     Delimiter:  _obvexits/delimiter" tell
+  " " tell
+  "   Simply set these properties to whatever you want them to be." tell
+  "   The name of the exits shown is determined by the name of the" tell
+  "   action attached to the room. The first name will be used, so" tell
+  "   \"<O>ut;out;o\" will be shown as just \"<O>ut\"." tell
+  " " tell
+  "   You can set these props anywhere in your environment, the program" tell
+  "   will look for them down from the room the looker is in." tell
+  "   That way it's trivial to use custom strings for a whole area." tell
+  " " tell
+  "   To make an exit visible if it's not by default, set the _visible?" tell
+  "   property on it to 'yes'." tell
+  " " tell
+  "   For information on how to change colors, see #help3." tell
+  " " tell
+;
+: ShowHelp3
+  HEADER dup tell
+  Underline tell
+  " " tell
+  "          CUSTOMIZING COLORS (OR: THE ART OF USING ANSI)" tell
+  " " tell
+  "   If you do not like the built-in ANSI color defaults (shame on you!)," tell
+  "   you can of course change them, even give every single exit a different" tell
+  "   color if you please. To do that, a couple properties are available" tell
+  "   to be set somewhere in the environment down from the exit itself." tell
+  " " tell
+  "   Prefix         :  _obvexits/color/prefix" tell
+  "   Delimiter      :  _obvexits/color/delimiter" tell
+  "   Normal Exits   :  _obvexits/color/normal" tell
+  "   Dark Exit      :  _obvexits/color/dark" tell
+  "   Program Action :  _obvexits/color/programs" tell
+  "   Unlinked Exit  :  _obvexits/color/unlinked" tell
+  " " tell
+  "   These properties take a 3 digit ansi color code like 010 for dark red." tell
+  " " tell
+  "   Only wizzes or exit owners see DARK/unlinked exits, if they set the" tell
+  "   _obvexits/debug flag on them to 'yes'. (@set me=_obvexits/debug:yes)" tell
+  " " tell
+;
+: main
+  dup not trigger @ exit? not AND if 
+    BuildList-loop exit 
+  then
+  
+  dup "#help" stringcmp not if
+    pop ShowGeneralHelp exit
+  then
+  
+  dup "#help2" stringcmp not if
+    pop ShowHelp2 exit
+  then
+ 
+  dup "#help3" stringcmp not if
+    pop ShowHelp3 exit
+  then
+  
+  ShowGeneralHelp
+;

--- a/triggur/hammers/morph-edit.muf
+++ b/triggur/hammers/morph-edit.muf
@@ -28,6 +28,9 @@ i
            - removed all dependence on $defines, all installation now
              done with the @install command.
    V1.50:  Nightwind pointed out an oddity with the MORPHCMD define.
+   V1.51:  - made FB7 compatible
+           - fixed install error that mixed up the scent and flight
+             props
 )
 
 $include $lib/lmgr
@@ -79,7 +82,7 @@ $define TIMEOUT prog PTIMEPROP getpropstr atoi $enddef
 $define DEFAULT_TIMEOUT 7200 $enddef
 
 ( program revision number )
-$define REVISION "1.50" $enddef 
+$define REVISION "1.51" $enddef 
 ( local storage prop for revision number )
 $define REVPROP "@/revision" $enddef
 ( the global command for morph )
@@ -137,7 +140,7 @@ lvar valcurr
   prog MORPHREG add-global-registry
 
 ( set default config params if unset )
-  prog PSCENTPROP getpropstr "" stringcmp not if  (flight )
+  prog PSCENTPROP getpropstr "" stringcmp not if  (scent )
      prog PSCENTPROP DEFAULT_SCENTPROP 0 addprop
   then
   prog PSAYPROP getpropstr "" stringcmp not if  (say )
@@ -155,7 +158,7 @@ lvar valcurr
 
 ( get new config params )
   prog PSCENTPROP DEFAULT_SCENTPROP
-      "What is the name of the player prop that determines if they can fly?"
+      "What is the name of the player prop that determines the player's scent?"
       SCENTPROP get-config-val 0 addprop
   prog PSAYPROP DEFAULT_SAYPROP
       "What is the name of the prop used by the SAY global that determines the speaker's FIRST PERSON say verb?"
@@ -226,7 +229,7 @@ lvar copy?
       pop 4 pick 4 pick propdir? not if
         "I don't see what property to "
         copy? @ if "copy." else "move." then
-        strcat .tell pop pop pop pop 0 exit
+        strcat tell pop pop pop pop 0 exit
       then
     then
   then
@@ -270,7 +273,7 @@ public mv-prop
   
 : parse-command ( s -- )
   command @ tolower
-  "command @ = \"" over strcat "\"" strcat .tell
+  "command @ = \"" over strcat "\"" strcat tell
   "c" instr copy? !
   
   dup "#help" stringcmp not if
@@ -292,18 +295,18 @@ public mv-prop
     depth EDITdisplay exit
   then
   
-  "," .split .strip swap .strip
-  "=" .split .strip swap .strip
+  "," split strip swap strip
+  "=" split strip swap strip
   dup if
-    .noisy_match
+    noisy_match
     dup not if pop exit then
   else
     over not if
       "Please enter the name of the original object."
-      .tell pop read .strip
+      tell pop read strip
     then
     dup if
-      .noisy_match
+      noisy_match
       dup not if pop exit then
     else pop me @
     then
@@ -312,22 +315,22 @@ public mv-prop
   begin
     strip-slashes
     dup not while
-    "Please enter the name of the original property." .tell
-    pop read .strip
+    "Please enter the name of the original property." tell
+    pop read strip
   repeat
   swap
-  "=" .split .strip strip-slashes swap .strip
+  "=" split strip strip-slashes swap strip
   begin
     over over or not while
     pop pop
-    "Please enter the name of the destination object." .tell
-    read .strip
-    "Please enter the name of the destination property." .tell
-    read .strip
+    "Please enter the name of the destination object." tell
+    read strip
+    "Please enter the name of the destination property." tell
+    read strip
     strip-slashes swap
   repeat
   dup if
-    .noisy_match
+    noisy_match
     dup not if pop exit then
   else
     pop 3 pick
@@ -339,7 +342,7 @@ public mv-prop
   cp-mv-prop if
     copy? @ if "Property copied."
     else "Property moved."
-    then .tell
+    then tell
   then
 ;
 ( -----------------end cmd-mv-cp code--------------------------- )
@@ -590,7 +593,7 @@ lvar camint2
     else
       pop "" morphcmd !
     then
-    .pmatch dup #-1 dbcmp 0 = not if
+    pmatch dup #-1 dbcmp 0 = not if
       me @ "Sorry, I don't know who that player is." notify 
       exit
     then
@@ -666,7 +669,7 @@ lvar camint2
 
   else dup "#allow" 6 strncmp not if (user about to get help)
     header
-    6 strcut swap pop strip .pmatch dup #-1 dbcmp 0 = not if
+    6 strcut swap pop strip pmatch dup #-1 dbcmp 0 = not if
       me @ "Sorry, I don't know who that player is." notify
       exit
     then

--- a/triggur/hammers/player-edit.muf
+++ b/triggur/hammers/player-edit.muf
@@ -24,6 +24,9 @@ i
           - Changed all $defines into configurable parameters
              {now installing this is easy as upload/@install, done.}
           - Fixed snapshot code to not create so many cameras
+  1.43    - compatibility with FB7
+          - Made scent prop configurable (e.g. use _prefs/smell for
+            FB7 starterdb)
 )
 
 $include $lib/lmgr
@@ -52,6 +55,9 @@ $define SAYPROP prog PSAYPROP getpropstr $enddef
 $define DEFAULT_OSAYPROP "_say/def/osay" $enddef
 $define POSAYPROP "@/osayprop" $enddef
 $define OSAYPROP prog POSAYPROP getpropstr $enddef
+$define DEFAULT_SCENTPROP "_scent" $enddef
+$define PSCENTPROP "@/scentprop" $enddef
+$define SCENTPROP prog PSCENTPROP getpropstr $enddef
 $define DEFAULT_DESCPROP "{look-notify:{eval:{list:redesc}}}" $enddef
 $define PDESCPROP "@/descprop" $enddef
 $define DESCPROP prog PDESCPROP getpropstr $enddef
@@ -65,7 +71,7 @@ $define TIMEOUT prog PTIMEPROP getpropstr atoi $enddef
 ( where we store our own revision )
 $define REVPROP "@/revision" $enddef
 ( current revision number of the program )
-$define REVISION "1.42" $enddef
+$define REVISION "1.43" $enddef
 ( editplayer command global )
 $define EPCMD "editplayer;ep" $enddef
 ( editplayer registry name )
@@ -130,6 +136,9 @@ lvar valcurr
   prog POSAYPROP getpropstr "" stringcmp not if  (osay )
      prog POSAYPROP DEFAULT_OSAYPROP 0 addprop
   then
+  prog PSCENTPROP getpropstr "" stringcmp not if (scent )
+     prog PSCENTPROP DEFAULT_SCENTPROP 0 addprop
+  then
   prog PDESCPROP getpropstr "" stringcmp not if  (desc )
      prog PDESCPROP DEFAULT_DESCPROP 0 addprop
   then
@@ -147,6 +156,9 @@ lvar valcurr
   prog POSAYPROP DEFAULT_OSAYPROP
       "What is the name of the prop used by the SAY global that determines the speaker's SECOND PERSON (osay) verb?"
       OSAYPROP get-config-val 0 addprop
+  prog PSCENTPROP DEFAULT_SCENTPROP
+      "What is the name of the prop used by the SMELL command that determines a player's scent?"
+      SCENTPROP get-config-val 0 addprop
   prog PDESCPROP DEFAULT_DESCPROP
       "What should I use for an MPI command to set as the player's description (the 'redesc' part is mandatory)?"
       DESCPROP get-config-val 0 addprop
@@ -321,7 +333,7 @@ lvar camint2
 
   me @ "8. You can " target @ FLYSTRING getpropstr "yes" stringcmp if "NOT " strcat then  "fly." strcat notify
 
-  me @ "9. Your smell message is '" target @ "_scent" getpropstr strcat "'." strcat notify
+  me @ "9. Your smell message is '" target @ SCENTPROP getpropstr strcat "'." strcat notify
 
   me @ "10. When you speak you see 'You " target @ "_say/def/say" getpropstr strcat " [...]'." strcat notify
 
@@ -532,7 +544,7 @@ exit
     me @ "Done.  Helpstaff request has been cleared." notify
     exit 
   else dup "#allow" 6 strncmp not if (user about to get help)
-    6 strcut swap pop strip .pmatch dup #-1 dbcmp 0 = not if
+    6 strcut swap pop strip pmatch dup #-1 dbcmp 0 = not if
       me @ "Sorry, I don't know who that player is." notify
       exit
     then
@@ -550,7 +562,7 @@ exit
     me @ "_helpstaff_assist_time" systime intostr 0 addprop
     exit
   else dup "#assist" 7 strncmp not if (user giving help)
-    7 strcut swap pop strip .pmatch dup #-1 dbcmp 0 = not if
+    7 strcut swap pop strip pmatch dup #-1 dbcmp 0 = not if
       me @ "Sorry, I don't know who that player is." notify 
       exit
     then
@@ -706,7 +718,7 @@ me @ "Sorry... the ability to change your name has been removed.  To do this, ex
         dup in-program-tell not if break then pop
       repeat
       dup "." stringcmp if
-        target @ swap "_scent" swap 0 addprop
+        target @ swap SCENTPROP swap 0 addprop
         target @ "_smell_notify" getpropstr not if  ( add default notify )
           target @ "_smell_notify" "+++++%N just smelled you!" 0 addprop
         then

--- a/triggur/lib-install/lib-install.muf
+++ b/triggur/lib-install/lib-install.muf
@@ -8,7 +8,7 @@ i
 ( V1.1  : {01/21/02} Wizbit check fix - Nightwind )
 ( V1.2  : {06/03/04} Wizbit check REAL fix, and bootstrap fix - Winged )
 ( V1.21 : {06/18/04} Make the program compile again - Schneelocke )
-
+( V1.22 : {08/03/21} Fixed setting _lib-name on the wrong obj - rook )
 
 $define THISVERSION "1.3" $enddef 
 $ifndef __version<Muck2.2fb6.01
@@ -166,7 +166,7 @@ lvar ltint1
   me @ "Registering library '" tstr1 @ strcat "'..." strcat notify
   #0 "_reg/lib/" tstr1 @ strcat tdb1 @ setprop
 
-  caller "_lib-name" tstr1 @ 0 addprop
+  tdb1 @ "_lib-name" tstr1 @ 0 addprop
 ;
 
 ( ------------------------------------------------------------------- )


### PR DESCRIPTION
Been going through the process of getting a lot of these scripts working on a fresh FB7 starterdb install... My primary goal was to get `cmd-editroom` and Triggur's player and morph hammers working.

This change adds some libraries:

- `lib-ansi-fb6.muf` by Wog, as a dependency for...
- `obvexits.muf` by Gyroplast, as a dependency for `cmd-editroom`

In `cmd-editroom.muf`:

- Reference `@$obvexits` by convention instead of `@$exits`.
- Replace missing dependency `findparent` with a simple call to `location` which... as far as I can tell does the trick. No idea what `findparent` was supposed to do other than that.

In `lib-tabtoolkit.muf`:

- FB7 updates

In `triggur/hammers/morph-edit.muf`:

- FB7 updates
- When installing, it asked you about flight props when setting scent props. Must have been a copy/paste error. Fixed.

In `triggur/hammers/player-edit.muf`:

- FB7 updates
- Made scent prop configurable, since FB7 starterdb's `smell` command looks at a different prop path.

In `triggur/lib-install/lib-install.muf`:

During self-installation, it set the `_lib-name` prop on the calling action for `$lib/install` but then later tried to access the same prop from the `$lib/install` script itself.

This led to the global defs being set up incorrectly, like:

```
> exa $lib/install=_defs/FUNCTION-WIZ-CHECK
- str /_defs/FUNCTION-WIZ-CHECK:"$lib/" match "FUNCTION-WIZ-CHECK" call
1 property listed.
```

(when correctly that `"$lib/"` should be `"$lib/install"`)

In turn, this led to problems like described [in this thread](https://sourceforge.net/p/fbmuck/discussion/4537/thread/1f3ce0a2/), where later programs attempting to `do-install` would resolve `"$lib/" MATCH` to `#-1` and exit with an error of `CALL: Invalid object.`

SO, all that is to say, re-installing `$lib/install` with this fix should get it working.