### PR TITLE
Fix Triggur lib-install, and fix my syntax error in player-edit.muf

### DIFF
--- a/triggur/hammers/player-edit.muf
+++ b/triggur/hammers/player-edit.muf
@@ -25,8 +25,8 @@ i
              {now installing this is easy as upload/@install, done.}
           - Fixed snapshot code to not create so many cameras
   1.43    - compatibility with FB7
-          - Made scent prop configurable (e.g. use _prefs/smell for
-            FB7 starterdb)
+          - Made scent prop configurable e.g. use _prefs/smell for
+            FB7 starterdb
 )
 
 $include $lib/lmgr

--- a/triggur/lib-install/lib-install.muf
+++ b/triggur/lib-install/lib-install.muf
@@ -9,6 +9,7 @@ i
 ( V1.2  : {06/03/04} Wizbit check REAL fix, and bootstrap fix - Winged )
 ( V1.21 : {06/18/04} Make the program compile again - Schneelocke )
 ( V1.22 : {08/03/21} Fixed setting _lib-name on the wrong obj - rook )
+( V1.23 : {08/04/21} Allow fresh install by name - rook )
 
 $define THISVERSION "1.3" $enddef 
 $ifndef __version<Muck2.2fb6.01
@@ -301,7 +302,7 @@ lvar ltint1
   then
 
   ( if it's NOTHING, we still need to find the program... ) 
-  ltdb1 @ NOTHING dbcmp not if ( -- )
+  ltdb1 @ NOTHING dbcmp if ( -- )
     GLOBALENV ( -- d )
     "_ver/" ltstr1 @ "/prog" strcat strcat ( -- d s )
     dup ltstr4 ! ( -- d s )   ( ...save propname for later use... )


### PR DESCRIPTION
This addresses the root cause of issue #28.

When performing an `@install` action on a brand new program, lib-install first tries to resolve to a dbref or to the name of an object referable in the caller's environment. However, if such an object is found and is a program, a reversed conditional led us down the path for when the object _can't_ be found, in which case the library tries to find the currently installed version of the program by that name. In the case of a program that's never been installed before, this does not exist. That yields the error

```
ERROR: #0=_ver/lib-install.muf/prog points to #0, which is not a program!
```

Inverting the conditional allows installation of a new program in your inventory or in the same room as you, without having to propset a dbref. 😃 

Also in this changeset: little fix to a comment from my previous change. I used a parenthetical within the comment, which is a syntax error!