### PR TITLE
READ BEFORE MERGE: Fix for 3who to work with FB 7.1

### DIFF
--- a/cmd-3who.muf
+++ b/cmd-3who.muf
@@ -33,8 +33,8 @@
 ;
  
 : collate-entry (i -- s)
-    dup condbref name
-    over contime mtimestr
+    dup descrdbref name
+    over descrtime mtimestr
     over strlen over strlen +
     dup 19 < if
         "                   " (19 spaces)
@@ -44,16 +44,16 @@
         strcut pop swap ""
     then
     swap strcat strcat
-    swap conidle stimestr strcat
+    swap descridle stimestr strcat
 ;
  
 : get-namelist  ( -- {s})
-    0 concount
+    0 #-1 firstdescr
     begin
-        dup 0 > while
+        dup while
         dup collate-entry
         rot 1 + rot
-        1 -
+        nextdescr
     repeat
     pop
 ;
@@ -89,7 +89,7 @@ lvar col
     "Name         Ontime Idle" strcat tell
     get-namelist
     show-namelist
-    concount intostr
+    descrcount intostr
     " players are connected."
     strcat tell
 ;

--- a/cmd-3who.muf
+++ b/cmd-3who.muf
@@ -1,6 +1,27 @@
 @program cmd-3who
 1 99999 d
 1 i
+(*
+ * Compatibility is an issue -- with FB 7.1, we got rid of a separate
+ * notion of connections vs. descriptors.  This block of code will
+ * [hopefully] retain backward compatibility
+ *)
+$ifdef __version>Muck2.2fb7.0
+$def CD_GET_DBREF descrdbref
+$def CD_GET_TIME descrtime
+$def CD_GET_IDLE descridle
+$def CD_GET_FIRST #-1 firstdescr
+$def CD_GET_NEXT nextdescr
+$def CD_GET_COUNT descrcount
+$else
+$def CD_GET_DBREF condbref
+$def CD_GET_TIME contime
+$def CD_GET_IDLE conidle
+$def CD_GET_FIRST concount
+$def CD_GET_NEXT 1 -
+$def CD_GET_COUNT concount
+$endif
+
 : stimestr (i -- s)
     dup 86400 > if
         86400 / intostr "d" strcat 
@@ -33,8 +54,8 @@
 ;
  
 : collate-entry (i -- s)
-    dup descrdbref name
-    over descrtime mtimestr
+    dup CD_GET_DBREF name
+    over CD_GET_TIME mtimestr
     over strlen over strlen +
     dup 19 < if
         "                   " (19 spaces)
@@ -44,16 +65,16 @@
         strcut pop swap ""
     then
     swap strcat strcat
-    swap descridle stimestr strcat
+    swap CD_GET_IDLE stimestr strcat
 ;
  
 : get-namelist  ( -- {s})
-    0 #-1 firstdescr
+    0 CD_GET_FIRST
     begin
         dup while
         dup collate-entry
         rot 1 + rot
-        nextdescr
+        CD_GET_NEXT
     repeat
     pop
 ;
@@ -89,7 +110,7 @@ lvar col
     "Name         Ontime Idle" strcat tell
     get-namelist
     show-namelist
-    descrcount intostr
+    CD_GET_COUNT intostr
     " players are connected."
     strcat tell
 ;


### PR DESCRIPTION
So FB 7.1 broke 3who since 3who relies on sequential connection numbers to work.  The fix was fairly easy.

The problem is, its technically a breaking fix as this makes the program incompatible.  We have, as I see it, three options:

1. Not care (currently selected option)
2. Use MUF macros to manage the pre-7.1 differences.  So, for example, ".firstdescr" could be a macro that just goes to "firstdescr" for 7.1 and "1 condescr" for pre-7.1.  MUCK owners make a conscious choice as to which set of MUF macros to isntall.
3. Some kind of `$ifdef` trickery.  I think there's a way to do an `$ifdef` based on MUCK version, but I can't remember how and it will probably take some digging in the C code to figure it out, unless @wyld-sw you remember the trick? :)

I really like option '3' but I don't know if it is actually possible.  I kind of don't like option '2' but it is dead simple to keep compatibility.  Or option '1' ... the chances of someone needing an old-arse version of this software are low and they can always get the old version from GIT history.  Perhaps add some comments around compatilibity and call it done?

Let me know your thoughts @wyld-sw and we'll do it!